### PR TITLE
Latest messages not toggled when switching chatrooms

### DIFF
--- a/src/components/chatroom/Chatroom.tsx
+++ b/src/components/chatroom/Chatroom.tsx
@@ -17,12 +17,14 @@ export const Chatroom = (props: {
   threadData: IThread
 }) => {
   const { firestore, auth, threadData } = props
+  const { id } = useParams<{ id: string }>()
   const messagesRef: firebase.firestore.CollectionReference = firestore.collection(
     'messages'
   )
   const query: firebase.firestore.Query<firebase.firestore.DocumentData> = messagesRef
     .orderBy('createdAt')
     .limit(25)
+    .where("threadId", "==", id)
   const [messages]: [
     IMessage[] | undefined,
     boolean,
@@ -30,7 +32,6 @@ export const Chatroom = (props: {
   ] = useCollectionData(query, { idField: 'id' })
 
   const [formMessage, setFormMessage] = useState('')
-  const { id } = useParams<{ id: string }>()
 
   useEffect(()=> {
     scrollToBottom()
@@ -64,17 +65,6 @@ export const Chatroom = (props: {
     }
   }
 
-  /**
-   * Return filtered messages based on thread
-   *
-   * @param message
-   */
-  const getFilteredMessages = (messages: IMessage[]) => {
-    return messages.filter(function (message: IMessage) {
-      return message?.threadId === id
-    })
-  }
-
   return (
     <div>
       <section className="hero is-primary is-small">
@@ -86,9 +76,8 @@ export const Chatroom = (props: {
       </section>
       <div id="messages" className="messages-window">
         {messages &&
-          getFilteredMessages(
-            (messages as unknown) as IMessage[]
-          ).map((message: IMessage) => (
+        ((messages as unknown) as IMessage[])
+          .map((message: IMessage) => (
             <Message key={message.id} message={message} auth={auth} />
           ))}
       </div>
@@ -103,7 +92,7 @@ export const Chatroom = (props: {
                 }
                 value={formMessage}
                 onChange={(e) => setFormMessage(e.target.value)}
-                disabled={threadData.isLocked ? true : false}
+                disabled={threadData.isLocked}
               />
             </div>
             <div className="control">


### PR DESCRIPTION
This PR started with the intention of closing #5.
But I saw an oportunity to optimize the amount of reads that the project does on firestore, per thread opening.
The previous behaviour is that we pulled all messages (limit: 25) from firestore, then filtered based on the threadId field.

This had several problems:
- It read all the messages in firestore, for each thread opening, even when the message wasn't from the thread that was opened
- It was limited to 25 messages, so let's say the following occurs:
  - I send 1 message in Chat Room 1
  - Then I send 25 messages in Chat Room 2
  - If i then open Chat Room 1, it would show no messages, even though there is 1 message in the chat
  - Now, with the new query, that limitation is gone, since we pull 25 messages that have a specific threadId
- It also eliminates the getFilteredMessages function and close #5.

Unfortunately, due to how Firestore works, for the new query to work, we have to create a index in the DB:
On the firebase console, on Firestore, in the Indexes tab, it should look like this:
![image](https://user-images.githubusercontent.com/41494576/136058210-c9e370c7-6d32-4b51-98bf-b79f2e722531.png)